### PR TITLE
Protect and redirect auth routes

### DIFF
--- a/zines-sns/package-lock.json
+++ b/zines-sns/package-lock.json
@@ -11,6 +11,7 @@
         "@heroui/react": "^2.2.9",
         "@heroui/theme": "^2.1.17",
         "@supabase/auth-helpers-nextjs": "^0.8.7",
+        "@supabase/ssr": "^0.6.1",
         "@supabase/supabase-js": "^2.39.1",
         "date-fns": "^3.0.6",
         "framer-motion": "^10.16.16",
@@ -5502,6 +5503,18 @@
         "ws": "^8.18.2"
       }
     },
+    "node_modules/@supabase/ssr": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@supabase/ssr/-/ssr-0.6.1.tgz",
+      "integrity": "sha512-QtQgEMvaDzr77Mk3vZ3jWg2/y+D8tExYF7vcJT+wQ8ysuvOeGGjYbZlvj5bHYsj/SpC0bihcisnwPrM4Gp5G4g==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.43.4"
+      }
+    },
     "node_modules/@supabase/storage-js": {
       "version": "2.10.4",
       "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.10.4.tgz",
@@ -7275,6 +7288,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/zines-sns/package.json
+++ b/zines-sns/package.json
@@ -15,6 +15,7 @@
     "@heroui/react": "^2.2.9",
     "@heroui/theme": "^2.1.17",
     "@supabase/auth-helpers-nextjs": "^0.8.7",
+    "@supabase/ssr": "^0.6.1",
     "@supabase/supabase-js": "^2.39.1",
     "date-fns": "^3.0.6",
     "framer-motion": "^10.16.16",

--- a/zines-sns/src/lib/supabase/client.ts
+++ b/zines-sns/src/lib/supabase/client.ts
@@ -1,6 +1,9 @@
-import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
+import { createBrowserClient } from '@supabase/ssr'
 import { Database } from '@/types/database'
 
 export function createClient() {
-  return createClientComponentClient<Database>()
+  return createBrowserClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  )
 }

--- a/zines-sns/src/lib/supabase/server.ts
+++ b/zines-sns/src/lib/supabase/server.ts
@@ -1,4 +1,4 @@
-import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
+import { createServerClient as createSupabaseServerClient, type CookieOptions } from '@supabase/ssr'
 import { cookies } from 'next/headers'
 import { Database } from '@/types/database'
 import { cache } from 'react'
@@ -7,17 +7,47 @@ import { createClient as createSupabaseClient } from '@supabase/supabase-js'
 // Create a cached version of the server client to prevent multiple instances
 export const createServerClient = cache(() => {
   const cookieStore = cookies()
-  return createServerComponentClient<Database>({ 
-    cookies: () => cookieStore
-  })
+  
+  return createSupabaseServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value
+        },
+        set(name: string, value: string, options: CookieOptions) {
+          cookieStore.set({ name, value, ...options })
+        },
+        remove(name: string, options: CookieOptions) {
+          cookieStore.set({ name, value: '', ...options })
+        },
+      },
+    }
+  )
 })
 
 // Server action client for mutations
 export async function createServerActionClient() {
   const cookieStore = cookies()
-  return createServerComponentClient<Database>({ 
-    cookies: () => cookieStore
-  })
+  
+  return createSupabaseServerClient<Database>(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value
+        },
+        set(name: string, value: string, options: CookieOptions) {
+          cookieStore.set({ name, value, ...options })
+        },
+        remove(name: string, options: CookieOptions) {
+          cookieStore.set({ name, value: '', ...options })
+        },
+      },
+    }
+  )
 }
 
 // Service role client for admin operations (use carefully!)


### PR DESCRIPTION
Migrate Supabase client setup to `@supabase/ssr` for improved Next.js App Router compatibility and maintain existing authentication protection.

The existing middleware already correctly handled the protection of `/create` and `/me` routes, redirecting unauthenticated users to `/auth/sign-in` with `returnTo`, and redirecting authenticated users from `/auth/*` routes. This PR updates the underlying Supabase client integration to use the modern `@supabase/ssr` package, replacing the deprecated `@supabase/auth-helpers-nextjs`, without altering the core authentication logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-23a6d93d-6e37-4ae5-85e6-b38abf082726">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-23a6d93d-6e37-4ae5-85e6-b38abf082726">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

