### PR TITLE
Create user profiles table and initial data

### DIFF
--- a/zines-sns/supabase/migrations/20240108_create_profiles_table.sql
+++ b/zines-sns/supabase/migrations/20240108_create_profiles_table.sql
@@ -1,0 +1,62 @@
+-- Migration: Create profiles table
+-- Date: 2024-01-08
+
+-- Enable UUID extension if not already enabled
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Create profiles table if it doesn't exist
+CREATE TABLE IF NOT EXISTS profiles (
+  id UUID PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  username TEXT UNIQUE NOT NULL,
+  avatar_url TEXT,
+  created_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc'::text, NOW()) NOT NULL,
+  updated_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc'::text, NOW()) NOT NULL
+);
+
+-- Create index on username for faster lookups
+CREATE INDEX IF NOT EXISTS idx_profiles_username ON profiles(username);
+
+-- Create index on created_at for sorting
+CREATE INDEX IF NOT EXISTS idx_profiles_created_at ON profiles(created_at DESC);
+
+-- Enable Row Level Security
+ALTER TABLE profiles ENABLE ROW LEVEL SECURITY;
+
+-- Drop existing policies if they exist
+DROP POLICY IF EXISTS "Public profiles are viewable by everyone" ON profiles;
+DROP POLICY IF EXISTS "Users can insert their own profile" ON profiles;
+DROP POLICY IF EXISTS "Users can update own profile" ON profiles;
+
+-- Create RLS policies for profiles
+CREATE POLICY "Public profiles are viewable by everyone" ON profiles
+  FOR SELECT USING (true);
+
+CREATE POLICY "Users can insert their own profile" ON profiles
+  FOR INSERT WITH CHECK (auth.uid() = id);
+
+CREATE POLICY "Users can update own profile" ON profiles
+  FOR UPDATE USING (auth.uid() = id);
+
+-- Create function for updated_at trigger if it doesn't exist
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = TIMEZONE('utc'::text, NOW());
+  RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+-- Create trigger for updating updated_at
+DROP TRIGGER IF EXISTS update_profiles_updated_at ON profiles;
+CREATE TRIGGER update_profiles_updated_at 
+  BEFORE UPDATE ON profiles
+  FOR EACH ROW 
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- Add comments
+COMMENT ON TABLE profiles IS 'User profiles with username and avatar information';
+COMMENT ON COLUMN profiles.id IS 'References auth.users id';
+COMMENT ON COLUMN profiles.username IS 'Unique username derived from email prefix';
+COMMENT ON COLUMN profiles.avatar_url IS 'URL to user avatar image';
+COMMENT ON COLUMN profiles.created_at IS 'Timestamp when profile was created';
+COMMENT ON COLUMN profiles.updated_at IS 'Timestamp when profile was last updated';

--- a/zines-sns/supabase/migrations/20240108_update_user_profile_creation.sql
+++ b/zines-sns/supabase/migrations/20240108_update_user_profile_creation.sql
@@ -1,0 +1,56 @@
+-- Migration: Update user profile creation to use email prefix as username and set default avatar
+-- Date: 2024-01-08
+
+-- Drop the existing trigger first
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+
+-- Drop the existing function
+DROP FUNCTION IF EXISTS public.handle_new_user();
+
+-- Create updated function to handle new user creation
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER AS $$
+DECLARE
+  username_value TEXT;
+  default_avatar_url TEXT;
+BEGIN
+  -- Extract username from email (part before @)
+  username_value := SPLIT_PART(NEW.email, '@', 1);
+  
+  -- Set default avatar URL (you can change this to your preferred default avatar)
+  default_avatar_url := 'https://api.dicebear.com/7.x/avataaars/svg?seed=' || NEW.id;
+  
+  -- Insert into profiles table
+  INSERT INTO public.profiles (id, username, avatar_url, created_at)
+  VALUES (
+    NEW.id,
+    username_value,
+    default_avatar_url,
+    NOW()
+  );
+  
+  RETURN NEW;
+EXCEPTION
+  WHEN unique_violation THEN
+    -- If username already exists, append a random suffix
+    username_value := username_value || '_' || substr(md5(random()::text), 1, 6);
+    
+    INSERT INTO public.profiles (id, username, avatar_url, created_at)
+    VALUES (
+      NEW.id,
+      username_value,
+      default_avatar_url,
+      NOW()
+    );
+    
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+-- Recreate the trigger
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();
+
+-- Add comment explaining the function
+COMMENT ON FUNCTION public.handle_new_user() IS 'Creates a user profile on signup with username from email prefix and default avatar';

--- a/zines-sns/supabase/migrations/README.md
+++ b/zines-sns/supabase/migrations/README.md
@@ -1,0 +1,63 @@
+# Supabase Migrations
+
+This directory contains SQL migration files for the ZINEs SNS application.
+
+## Migrations
+
+### 20240108_create_profiles_table.sql
+- Creates the `profiles` table with the following columns:
+  - `id` (UUID) - Primary key referencing auth.users(id)
+  - `username` (TEXT) - Unique username derived from email prefix
+  - `avatar_url` (TEXT) - URL to user's avatar image
+  - `created_at` (TIMESTAMP) - Profile creation timestamp
+  - `updated_at` (TIMESTAMP) - Last update timestamp
+- Sets up Row Level Security policies
+- Creates indexes for performance
+- Adds update trigger for `updated_at` column
+
+### 20240108_update_user_profile_creation.sql
+- Updates the `handle_new_user()` function to:
+  - Extract username from email (part before @)
+  - Set a default avatar URL using DiceBear API with user ID as seed
+  - Handle username conflicts by appending a random suffix
+- Ensures new user profiles are created automatically on sign-up
+
+## How to Apply Migrations
+
+### Option 1: Using Supabase CLI (Recommended)
+```bash
+# Apply all migrations
+supabase db push
+
+# Or apply specific migration
+supabase db push --file supabase/migrations/20240108_create_profiles_table.sql
+supabase db push --file supabase/migrations/20240108_update_user_profile_creation.sql
+```
+
+### Option 2: Using Supabase Dashboard
+1. Go to your Supabase project dashboard
+2. Navigate to SQL Editor
+3. Copy and paste the migration content
+4. Execute the SQL
+
+### Option 3: Direct Database Connection
+```bash
+# Connect to your database and run
+psql -h your-db-host -U postgres -d your-db-name -f supabase/migrations/20240108_create_profiles_table.sql
+psql -h your-db-host -U postgres -d your-db-name -f supabase/migrations/20240108_update_user_profile_creation.sql
+```
+
+## Important Notes
+
+1. **Order Matters**: Apply `20240108_create_profiles_table.sql` before `20240108_update_user_profile_creation.sql`
+2. **Default Avatar**: The migration uses DiceBear API for generating default avatars. You can change this by modifying the `default_avatar_url` in the migration.
+3. **Username Conflicts**: If a username already exists (e.g., multiple users with email john@example.com), the system appends a random 6-character suffix.
+
+## Testing
+
+After applying migrations, test the sign-up flow:
+1. Sign up with a new email
+2. Check that a profile is created with:
+   - Username = email prefix (e.g., "john" from "john@example.com")
+   - Avatar URL = DiceBear generated avatar
+   - Proper timestamps


### PR DESCRIPTION
Implements SQL migrations to create a `profiles` table and update the user signup trigger to automatically create profiles with email-derived usernames and default avatars.

---
<a href="https://cursor.com/background-agent?bcId=bc-96b61924-480e-4711-8373-fb828e3388c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-96b61924-480e-4711-8373-fb828e3388c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

