### PR TITLE
Fix post submission display issue

### DIFF
--- a/src/app/[locale]/create/CreateForm.tsx
+++ b/src/app/[locale]/create/CreateForm.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { createPostAction } from "./actions";
 import { Button, Input, Card, CardBody, Chip, Image, Spinner } from "@heroui/react";
 import { Icon } from "@/components/ui/Icon";
+import { useRouter } from "next/navigation";
 
 export default function CreateForm() {
   const [pending, setPending] = useState(false);
@@ -11,6 +12,7 @@ export default function CreateForm() {
   const [imagePreviews, setImagePreviews] = useState<string[]>([]);
   const [tags, setTags] = useState<string[]>([]);
   const [tagInput, setTagInput] = useState("");
+  const router = useRouter();
 
   async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -34,6 +36,12 @@ export default function CreateForm() {
         form.reset();
         setImagePreviews([]);
         setTags([]);
+        
+        // Redirect to user's profile page after a short delay
+        setTimeout(() => {
+          router.push('/me');
+          router.refresh(); // Force refresh to show new content
+        }, 500);
       }
     } finally {
       setPending(false);

--- a/src/app/[locale]/create/actions.ts
+++ b/src/app/[locale]/create/actions.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createServerClient } from "@/lib/supabase/server";
+import { revalidatePath } from "next/cache";
 
 export async function createPostAction(formData: FormData) {
   const supabase = createServerClient();
@@ -66,13 +67,13 @@ export async function createPostAction(formData: FormData) {
     title: string;
     body: string;
     tags: string[] | null;
-    image_urls: string[];
+    images: string[];
   } = {
     user_id: user.id,
     title: titleRaw.trim() || "Untitled",
     body: bodyRaw ?? "",
     tags: tags.length ? tags : null,
-    image_urls: imageUrls,
+    images: imageUrls,
   };
 
   // undefined 除去（安全策）
@@ -96,6 +97,12 @@ export async function createPostAction(formData: FormData) {
       user.id;
     return { ok: false, error: msg };
   }
+
+  // Revalidate paths to ensure fresh data
+  revalidatePath('/');
+  revalidatePath('/[locale]', 'page');
+  revalidatePath('/[locale]/me', 'page');
+  revalidatePath(`/me`);
 
   return { ok: true, error: null };
 }

--- a/src/components/posts/MyPostsGrid.tsx
+++ b/src/components/posts/MyPostsGrid.tsx
@@ -27,6 +27,17 @@ export function MyPostsGrid({ userId, onEmptyState }: MyPostsGridProps) {
     loadPosts(true)
   }, [userId])
 
+  // Refresh posts when component mounts or pathname changes
+  useEffect(() => {
+    const handleFocus = () => {
+      // Refresh posts when window regains focus
+      loadPosts(true)
+    }
+    
+    window.addEventListener('focus', handleFocus)
+    return () => window.removeEventListener('focus', handleFocus)
+  }, [])
+
   const loadPosts = async (initial = false) => {
     if (!initial && (!hasMore || loadingMore)) return
     

--- a/src/components/posts/PostGrid.tsx
+++ b/src/components/posts/PostGrid.tsx
@@ -22,6 +22,11 @@ export function PostGrid({ initialPosts, loadMore, hasMore = false, enableLoadMo
   const router = useRouter()
   const loadMoreRef = useRef<() => Promise<PostWithProfile[]>>()
 
+  // Update posts when initialPosts change (e.g., after router.refresh())
+  useEffect(() => {
+    setPosts(initialPosts)
+  }, [initialPosts])
+
   const lastPostElementRef = useCallback(
     (node: HTMLDivElement) => {
       if (loading) return


### PR DESCRIPTION
Ensure newly created posts are immediately reflected on the user's profile and home pages.

The previous implementation suffered from a database field name mismatch (`image_urls` vs `images`), a lack of client-side redirection and refresh after post submission, and missing server-side cache revalidation. This PR addresses these issues by correcting the field name, adding a redirect with `router.refresh()`, and implementing `revalidatePath` calls, along with client-side refresh enhancements, to ensure immediate data consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-9083418c-c4e4-4d9e-bd72-6134ea85d1ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9083418c-c4e4-4d9e-bd72-6134ea85d1ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

