### PR TITLE
Fix post creation image column error

### DIFF
--- a/src/app/[locale]/create/CreateForm.tsx
+++ b/src/app/[locale]/create/CreateForm.tsx
@@ -32,7 +32,12 @@ export default function CreateForm() {
       if (!res.ok) {
         setMessage(res.error || "Failed to create post");
       } else {
-        setMessage("Post created successfully!");
+        // Check if there's a warning
+        if ('warning' in res && res.warning) {
+          setMessage(res.warning);
+        } else {
+          setMessage("Post created successfully!");
+        }
         form.reset();
         setImagePreviews([]);
         setTags([]);

--- a/supabase/migrations/20240109_add_posts_images_column.sql
+++ b/supabase/migrations/20240109_add_posts_images_column.sql
@@ -1,0 +1,15 @@
+-- Check if images column exists and add it if not
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 
+    FROM information_schema.columns 
+    WHERE table_schema = 'public' 
+    AND table_name = 'posts' 
+    AND column_name = 'images'
+  ) THEN
+    ALTER TABLE posts 
+    ADD COLUMN images TEXT[] NOT NULL DEFAULT '{}' 
+    CHECK (array_length(images, 1) > 0 AND array_length(images, 1) <= 3);
+  END IF;
+END $$;


### PR DESCRIPTION
Implement robust post creation with retry logic and a migration to address Supabase schema cache issues with the `images` column.

The "Could not find the 'images' column" error prevented post creation. This PR introduces a multi-attempt insert strategy in `createPostAction` to ensure posts can always be created, falling back to omitting images if necessary, and provides a migration to explicitly add the `images` column to the `posts` table.

---
<a href="https://cursor.com/background-agent?bcId=bc-764bb915-7219-4145-9cd9-64918dd203ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-764bb915-7219-4145-9cd9-64918dd203ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

