### PR TITLE
Update image field to image_urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ src/
 
 The app uses the following main tables:
 - `profiles` - User profiles
-- `posts` - ZINE posts with images, title, body, and tags
+- `posts` - ZINE posts with image_urls, title, body, and tags
 - `follows` - Follow relationships
 - `likes` - Post likes
 

--- a/src/app/[locale]/create/actions.ts
+++ b/src/app/[locale]/create/actions.ts
@@ -72,7 +72,7 @@ export async function createPostAction(formData: FormData): Promise<CreatePostRe
     title: titleRaw.trim() || "Untitled",
     body: bodyRaw ?? "",
     tags: tags.length ? tags : [],
-    images: imageUrls,
+    image_urls: imageUrls,
   };
 
   const { data: newPost, error: insErr } = await supabase
@@ -83,7 +83,7 @@ export async function createPostAction(formData: FormData): Promise<CreatePostRe
 
   if (insErr) {
     // If standard insert fails due to schema cache, try a different approach
-    if (insErr.message?.includes("schema cache") || insErr.message?.includes("images")) {
+    if (insErr.message?.includes("schema cache") || insErr.message?.includes("image_urls")) {
       // Try inserting without the type annotation and ensure arrays are properly formatted
       const { data: retryPost, error: retryErr } = await supabase
         .from("posts")
@@ -92,13 +92,13 @@ export async function createPostAction(formData: FormData): Promise<CreatePostRe
           title: titleRaw.trim() || "Untitled",
           body: bodyRaw ?? "",
           tags: tags.length ? tags : [],
-          images: imageUrls
+          image_urls: imageUrls
         }])
         .select()
         .single();
 
       if (retryErr) {
-        // As a last resort, try without images to ensure posts can be created
+        // As a last resort, try without image_urls to ensure posts can be created
         const { data: fallbackPost, error: fallbackErr } = await supabase
           .from("posts")
           .insert([{
@@ -106,7 +106,7 @@ export async function createPostAction(formData: FormData): Promise<CreatePostRe
             title: titleRaw.trim() || "Untitled",
             body: bodyRaw ?? "",
             tags: tags.length ? tags : []
-            // Temporarily omit images field
+            // Temporarily omit image_urls field
           }])
           .select()
           .single();
@@ -124,7 +124,7 @@ export async function createPostAction(formData: FormData): Promise<CreatePostRe
           return { ok: false, error: msg };
         }
         
-        // Post created without images - notify user
+        // Post created without image_urls - notify user
         return { 
           ok: true, 
           postId: fallbackPost.id,

--- a/src/app/[locale]/post/[postId]/page.tsx
+++ b/src/app/[locale]/post/[postId]/page.tsx
@@ -25,9 +25,9 @@ export default async function PostDetailPage({ params }: { params: { postId: str
     <div className="min-h-screen bg-background p-4">
       <h1 className="text-2xl font-bold mb-4">{post.title || 'Untitled'}</h1>
       {post.body && <p className="mb-4">{post.body}</p>}
-      {post.images && post.images.length > 0 && (
+      {post.image_urls && post.image_urls.length > 0 && (
         <div className="grid gap-4">
-          {post.images.map((image: string, index: number) => (
+          {post.image_urls.map((image: string, index: number) => (
             <img
               key={index}
               src={image}

--- a/src/components/posts/MyPostsGrid.tsx
+++ b/src/components/posts/MyPostsGrid.tsx
@@ -119,9 +119,9 @@ export function MyPostsGrid({ userId, onEmptyState }: MyPostsGridProps) {
             onClick={() => handlePostClick(post.id)}
             style={{ aspectRatio: '1 / 1' }}
           >
-            {post.images && post.images[0] && (
+            {post.image_urls && post.image_urls[0] && (
               <Image
-                src={post.images[0]}
+                src={post.image_urls[0]}
                 alt={post.title || 'Post image'}
                 fill
                 sizes="(max-width: 640px) 33vw, 25vw"

--- a/src/components/posts/PostGrid.tsx
+++ b/src/components/posts/PostGrid.tsx
@@ -86,7 +86,7 @@ export function PostGrid({ initialPosts, loadMore, hasMore = false, enableLoadMo
           >
             <div className="aspect-square-content">
               <Image
-                src={post.images[0]}
+                src={post.image_urls[0]}
                 alt={post.title || 'Post image'}
                 fill
                 sizes="(max-width: 640px) 33vw, 25vw"

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -38,7 +38,7 @@ export interface Database {
           user_id: string
           title: string | null
           body: string | null
-          images: string[]
+          image_urls: string[]
           tags: string[]
           created_at: string
           updated_at: string
@@ -48,7 +48,7 @@ export interface Database {
           user_id: string
           title?: string | null
           body?: string | null
-          images: string[]
+          image_urls: string[]
           tags?: string[]
           created_at?: string
           updated_at?: string
@@ -58,7 +58,7 @@ export interface Database {
           user_id?: string
           title?: string | null
           body?: string | null
-          images?: string[]
+          image_urls?: string[]
           tags?: string[]
           created_at?: string
           updated_at?: string

--- a/supabase/migrations/20240110_rename_images_to_image_urls.sql
+++ b/supabase/migrations/20240110_rename_images_to_image_urls.sql
@@ -1,0 +1,40 @@
+-- Rename images column to image_urls in posts table
+DO $$
+BEGIN
+  -- Check if the images column exists and image_urls doesn't exist
+  IF EXISTS (
+    SELECT 1 
+    FROM information_schema.columns 
+    WHERE table_schema = 'public' 
+    AND table_name = 'posts' 
+    AND column_name = 'images'
+  ) AND NOT EXISTS (
+    SELECT 1 
+    FROM information_schema.columns 
+    WHERE table_schema = 'public' 
+    AND table_name = 'posts' 
+    AND column_name = 'image_urls'
+  ) THEN
+    -- Rename the column
+    ALTER TABLE posts RENAME COLUMN images TO image_urls;
+  END IF;
+END $$;
+
+-- Update the function to use image_urls instead of images
+CREATE OR REPLACE FUNCTION insert_post_with_images(
+  p_user_id UUID,
+  p_title TEXT,
+  p_body TEXT,
+  p_tags TEXT[],
+  p_image_urls TEXT[]
+) RETURNS posts AS $$
+DECLARE
+  new_post posts;
+BEGIN
+  INSERT INTO posts (user_id, title, body, tags, image_urls)
+  VALUES (p_user_id, p_title, p_body, p_tags, p_image_urls)
+  RETURNING * INTO new_post;
+  
+  RETURN new_post;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -16,7 +16,7 @@ CREATE TABLE posts (
   user_id UUID NOT NULL REFERENCES profiles(id) ON DELETE CASCADE,
   title TEXT CHECK (char_length(title) <= 64),
   body TEXT CHECK (char_length(body) <= 32),
-  images TEXT[] NOT NULL CHECK (array_length(images, 1) > 0 AND array_length(images, 1) <= 3),
+  image_urls TEXT[] NOT NULL CHECK (array_length(image_urls, 1) > 0 AND array_length(image_urls, 1) <= 3),
   tags TEXT[] DEFAULT '{}',
   created_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc'::text, NOW()) NOT NULL,
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT TIMEZONE('utc'::text, NOW()) NOT NULL
@@ -188,19 +188,19 @@ CREATE POLICY "Users can update own post images" ON storage.objects
 CREATE POLICY "Users can delete own post images" ON storage.objects
   FOR DELETE USING (bucket_id = 'posts' AND auth.uid()::text = (storage.foldername(name))[1]);
 
--- Create function to insert posts with images
+-- Create function to insert posts with image_urls
 CREATE OR REPLACE FUNCTION insert_post_with_images(
   p_user_id UUID,
   p_title TEXT,
   p_body TEXT,
   p_tags TEXT[],
-  p_images TEXT[]
+  p_image_urls TEXT[]
 ) RETURNS posts AS $$
 DECLARE
   new_post posts;
 BEGIN
-  INSERT INTO posts (user_id, title, body, tags, images)
-  VALUES (p_user_id, p_title, p_body, p_tags, p_images)
+  INSERT INTO posts (user_id, title, body, tags, image_urls)
+  VALUES (p_user_id, p_title, p_body, p_tags, p_image_urls)
   RETURNING * INTO new_post;
   
   RETURN new_post;


### PR DESCRIPTION
Rename `images` field to `image_urls` across the application and database to align with the Supabase `posts` table schema.

This change ensures consistency between the application's data models, API calls, and the actual Supabase database column name. A migration file is included to rename the column for existing deployments.

---
<a href="https://cursor.com/background-agent?bcId=bc-074a42ca-483c-4ac3-b47b-e85f73dac3eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-074a42ca-483c-4ac3-b47b-e85f73dac3eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

