### PR TITLE
Simulate signup with server error

### DIFF
--- a/src/app/[locale]/auth/callback/route.ts
+++ b/src/app/[locale]/auth/callback/route.ts
@@ -1,8 +1,6 @@
-import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs'
-import { cookies } from 'next/headers'
+import { createServerClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
-import type { Database } from '@/types/database'
 
 export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url)
@@ -21,10 +19,7 @@ export async function GET(request: NextRequest) {
   }
 
   if (code) {
-    const cookieStore = cookies()
-    const supabase = createRouteHandlerClient<Database>(
-      { cookies: () => cookieStore }
-    )
+    const supabase = createServerClient()
 
     try {
       // Exchange code for session

--- a/src/app/api/test-signup/route.ts
+++ b/src/app/api/test-signup/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server'
+import { createServerClient } from '@/lib/supabase/server'
+
+export async function POST(request: Request) {
+  try {
+    const { email, password } = await request.json()
+    
+    const supabase = createServerClient()
+    
+    // Try to sign up
+    const { data, error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: {
+        emailRedirectTo: `${process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000'}/auth/callback`,
+      },
+    })
+    
+    if (error) {
+      console.error('Sign up error:', error)
+      return NextResponse.json({ 
+        error: error.message,
+        details: error,
+        code: error.code 
+      }, { status: 400 })
+    }
+    
+    // Check if profile was created
+    if (data?.user) {
+      const { data: profile, error: profileError } = await supabase
+        .from('profiles')
+        .select('*')
+        .eq('id', data.user.id)
+        .single()
+        
+      return NextResponse.json({ 
+        success: true,
+        user: data.user,
+        profile: profile,
+        profileError: profileError
+      })
+    }
+    
+    return NextResponse.json({ success: true, data })
+  } catch (error) {
+    console.error('Unexpected error:', error)
+    return NextResponse.json({ 
+      error: 'Internal server error', 
+      details: error instanceof Error ? error.message : 'Unknown error' 
+    }, { status: 500 })
+  }
+}

--- a/test-signup.html
+++ b/test-signup.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Sign Up</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            max-width: 600px;
+            margin: 50px auto;
+            padding: 20px;
+        }
+        input, button {
+            display: block;
+            width: 100%;
+            margin: 10px 0;
+            padding: 10px;
+            font-size: 16px;
+        }
+        button {
+            background-color: #4CAF50;
+            color: white;
+            border: none;
+            cursor: pointer;
+        }
+        button:hover {
+            background-color: #45a049;
+        }
+        .error {
+            color: red;
+            margin: 10px 0;
+        }
+        .success {
+            color: green;
+            margin: 10px 0;
+        }
+        pre {
+            background-color: #f4f4f4;
+            padding: 10px;
+            overflow: auto;
+        }
+    </style>
+</head>
+<body>
+    <h1>Test Sign Up</h1>
+    
+    <form id="signupForm">
+        <input type="email" id="email" placeholder="Email" required>
+        <input type="password" id="password" placeholder="Password (min 8 characters)" required>
+        <button type="submit">Test Sign Up</button>
+    </form>
+    
+    <div id="result"></div>
+    
+    <script>
+        document.getElementById('signupForm').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            
+            const email = document.getElementById('email').value;
+            const password = document.getElementById('password').value;
+            const resultDiv = document.getElementById('result');
+            
+            resultDiv.innerHTML = '<p>Testing sign up...</p>';
+            
+            try {
+                const response = await fetch('/api/test-signup', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify({ email, password }),
+                });
+                
+                const data = await response.json();
+                
+                if (response.ok) {
+                    resultDiv.innerHTML = `
+                        <div class="success">
+                            <h3>Sign up successful!</h3>
+                            <pre>${JSON.stringify(data, null, 2)}</pre>
+                        </div>
+                    `;
+                } else {
+                    resultDiv.innerHTML = `
+                        <div class="error">
+                            <h3>Sign up failed!</h3>
+                            <p>Status: ${response.status}</p>
+                            <pre>${JSON.stringify(data, null, 2)}</pre>
+                        </div>
+                    `;
+                }
+            } catch (error) {
+                resultDiv.innerHTML = `
+                    <div class="error">
+                        <h3>Network error!</h3>
+                        <p>${error.message}</p>
+                    </div>
+                `;
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Update Supabase client in auth callback route and add sign-up test utilities to resolve 500 error.

The 500 error during sign-up was caused by the `/auth/callback` route using the deprecated `@supabase/auth-helpers-nextjs` client (`createRouteHandlerClient`) while the rest of the application used `@supabase/ssr` (`createServerClient`). This PR updates the callback to use the consistent `createServerClient` from the application's Supabase configuration. Additionally, a test API route and HTML page were added to provide better debugging capabilities for sign-up issues, including potential problems with the `on_auth_user_created` database trigger.

---
<a href="https://cursor.com/background-agent?bcId=bc-a73a4a2d-9465-4c56-b4db-0b5d9c3a9e17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a73a4a2d-9465-4c56-b4db-0b5d9c3a9e17">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

