### PR TITLE
Unify back navigation and FAB on posting screen

### DIFF
--- a/src/app/[locale]/create/page.tsx
+++ b/src/app/[locale]/create/page.tsx
@@ -1,6 +1,8 @@
 import { serverAuthGuard } from "@/lib/auth/server-guards";
 import { Metadata } from "next";
 import CreateForm from "./CreateForm";
+import { FABNavigation } from '@/components/navigation/FABNavigation';
+import { getTranslations } from 'next-intl/server';
 import Link from "next/link";
 import { Button } from "@heroui/react";
 import { Icon } from "@/components/ui/Icon";
@@ -12,6 +14,13 @@ export const metadata: Metadata = {
 
 export default async function CreatePage() {
   await serverAuthGuard({ returnTo: "/create" });
+  const t = await getTranslations();
+  
+  const fabItems = [
+    { icon: 'home', label: t('common.home'), path: '/' },
+    { icon: 'person', label: t('settings.profile'), path: '/me' },
+    { icon: 'settings', label: t('common.settings'), path: '/settings' },
+  ];
   
   return (
     <>
@@ -21,7 +30,7 @@ export default async function CreatePage() {
       </div>
       
       {/* FAB Back Button */}
-      <div className="fixed bottom-4 left-4 z-50">
+      <div className="fixed bottom-6 left-6 z-50">
         <Button
           as={Link}
           href="/"
@@ -34,6 +43,9 @@ export default async function CreatePage() {
           <Icon name="chevron_backward" size="lg" />
         </Button>
       </div>
+      
+      {/* FAB Navigation Menu */}
+      <FABNavigation items={fabItems} />
     </>
   );
 }


### PR DESCRIPTION
Integrate the main navigation FAB on the posting screen to unify the user experience while retaining the dedicated back button.

---
<a href="https://cursor.com/background-agent?bcId=bc-259b2bd8-23be-4843-a5ae-eab6d5c2a7e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-259b2bd8-23be-4843-a5ae-eab6d5c2a7e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

