### PR TITLE
Unify back navigation with post FAB

### DIFF
--- a/src/app/[locale]/me/avatar/page.tsx
+++ b/src/app/[locale]/me/avatar/page.tsx
@@ -11,6 +11,7 @@ import { useProfile } from '@/hooks/useProfile'
 import { AvatarUpload } from '@/components/profile/AvatarUpload'
 import { uploadAvatar, deleteAvatar } from '@/lib/supabase/storage'
 import { toast } from 'sonner'
+import { BackButton } from '@/components/navigation/BackButton'
 
 export default function AvatarEditPage() {
   const t = useTranslations()
@@ -138,14 +139,7 @@ export default function AvatarEditPage() {
       <div className="min-h-screen bg-background">
         <div className="max-w-[480px] mx-auto">
           <div className="flex items-center gap-3 p-4 bg-content1 border-b">
-            <Button
-              isIconOnly
-              variant="light"
-              onPress={handleBack}
-              className="material-symbols-rounded"
-            >
-              arrow_back
-            </Button>
+            <BackButton variant="header" />
             <h1 className="text-lg font-semibold">{t('settings.profileSettings.avatar')}</h1>
           </div>
           <div className="p-4">
@@ -161,14 +155,7 @@ export default function AvatarEditPage() {
       <div className="max-w-[480px] mx-auto">
         {/* Header */}
         <div className="flex items-center gap-3 p-4 bg-content1 border-b">
-          <Button
-            isIconOnly
-            variant="light"
-            onPress={handleBack}
-            className="material-symbols-rounded"
-          >
-            arrow_back
-          </Button>
+          <BackButton variant="header" />
           <h1 className="text-lg font-semibold">{t('settings.profileSettings.avatar')}</h1>
         </div>
         

--- a/src/app/[locale]/me/email/page.tsx
+++ b/src/app/[locale]/me/email/page.tsx
@@ -11,6 +11,7 @@ import { useState } from 'react'
 import { useAuth } from '@/components/providers/AuthProvider'
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
 import { toast } from 'sonner'
+import { BackButton } from '@/components/navigation/BackButton'
 
 export default function EmailEditPage() {
   const t = useTranslations()
@@ -115,14 +116,7 @@ export default function EmailEditPage() {
       <div className="max-w-[480px] mx-auto">
         {/* Header */}
         <div className="flex items-center gap-3 p-4 bg-content1 border-b">
-          <Button
-            isIconOnly
-            variant="light"
-            onPress={handleBack}
-            className="material-symbols-rounded"
-          >
-            arrow_back
-          </Button>
+          <BackButton variant="header" />
           <h1 className="text-lg font-semibold flex-1">{t('auth.email')}</h1>
           <Button
             color="primary"

--- a/src/app/[locale]/post/[postId]/PostDetailClient.tsx
+++ b/src/app/[locale]/post/[postId]/PostDetailClient.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation'
 import { Card, CardBody, Button, Chip } from '@heroui/react'
 import { Icon } from '@/components/ui/Icon'
 import { motion } from 'framer-motion'
+import { BackButton } from '@/components/navigation/BackButton'
 
 interface PostDetailClientProps {
   post: any
@@ -16,9 +17,7 @@ export function PostDetailClient({ post, locale }: PostDetailClientProps) {
   const router = useRouter()
   const [currentImageIndex, setCurrentImageIndex] = useState(0)
 
-  const handleBack = () => {
-    router.back()
-  }
+
 
   const handleNextImage = () => {
     if (post.image_urls && currentImageIndex < post.image_urls.length - 1) {
@@ -37,14 +36,7 @@ export function PostDetailClient({ post, locale }: PostDetailClientProps) {
       {/* Header */}
       <div className="sticky top-0 z-50 bg-background/80 backdrop-blur-md border-b">
         <div className="max-w-4xl mx-auto px-4 py-3 flex items-center gap-4">
-          <Button
-            isIconOnly
-            variant="light"
-            onPress={handleBack}
-            className="rounded-full"
-          >
-            <Icon name="arrow_back" />
-          </Button>
+          <BackButton variant="header" />
           <h1 className="text-lg font-semibold">Post Details</h1>
         </div>
       </div>

--- a/src/app/[locale]/settings/page.tsx
+++ b/src/app/[locale]/settings/page.tsx
@@ -15,6 +15,7 @@ import { uploadAvatar, deleteAvatar } from '@/lib/supabase/storage'
 import { getProfile, updateProfile, checkUsernameAvailability } from '@/lib/services/profile'
 import { useDebounce } from '@/hooks/useDebounce'
 import { toast } from 'sonner'
+import { BackButton } from '@/components/navigation/BackButton'
 
 export default function SettingsPage() {
   const t = useTranslations()
@@ -193,14 +194,7 @@ export default function SettingsPage() {
   return (
     <div className="space-y-6">
       <div className="flex items-center gap-2 mb-6">
-        <Button
-          isIconOnly
-          variant="light"
-          onPress={() => router.back()}
-          className="material-symbols-rounded"
-        >
-          arrow_back
-        </Button>
+        <BackButton variant="header" />
         <h1 className="text-2xl font-bold">{t('settings.title')}</h1>
       </div>
       

--- a/src/components/navigation/BackButton.tsx
+++ b/src/components/navigation/BackButton.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { Button } from '@heroui/react'
+import { useRouter } from 'next/navigation'
+import { motion } from 'framer-motion'
+
+interface BackButtonProps {
+  onPress?: () => void
+  variant?: 'fab' | 'header'
+  className?: string
+}
+
+export function BackButton({ onPress, variant = 'fab', className = '' }: BackButtonProps) {
+  const router = useRouter()
+  
+  const handleBack = () => {
+    if (onPress) {
+      onPress()
+    } else {
+      router.back()
+    }
+  }
+
+  if (variant === 'fab') {
+    return (
+      <motion.div
+        initial={{ opacity: 0, scale: 0.8 }}
+        animate={{ opacity: 1, scale: 1 }}
+        transition={{ duration: 0.2 }}
+      >
+        <Button
+          isIconOnly
+          color="primary"
+          variant="shadow"
+          size="lg"
+          className={`w-14 h-14 ${className}`}
+          onPress={handleBack}
+          title="Go back"
+        >
+          <span className="material-symbols-rounded text-2xl">
+            arrow_back
+          </span>
+        </Button>
+      </motion.div>
+    )
+  }
+
+  // Header variant for sticky headers
+  return (
+    <Button
+      isIconOnly
+      variant="light"
+      onPress={handleBack}
+      className={`rounded-full ${className}`}
+    >
+      <span className="material-symbols-rounded">
+        arrow_back
+      </span>
+    </Button>
+  )
+}


### PR DESCRIPTION
Introduce a reusable `BackButton` component to unify back navigation across post details and settings screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf8eb3fc-d00b-4b28-ac2e-152585b7558b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf8eb3fc-d00b-4b28-ac2e-152585b7558b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

