### PR TITLE
Investigate input component size discrepancy

### DIFF
--- a/src/app/[locale]/create/CreateForm.tsx
+++ b/src/app/[locale]/create/CreateForm.tsx
@@ -201,7 +201,7 @@ export default function CreateForm() {
                 onKeyDown={handleTagInputKeyDown}
                 placeholder="Add a tag..."
                 variant="bordered"
-                size="sm"
+                size="md"
                 disabled={tags.length >= 10}
               />
               <Button


### PR DESCRIPTION
Update tag input size from 'sm' to 'md' to ensure visual consistency with adjacent components and HeroUI defaults.

---
<a href="https://cursor.com/background-agent?bcId=bc-dfe4c45a-8eef-4616-ae51-5fe95b4cd953">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dfe4c45a-8eef-4616-ae51-5fe95b4cd953">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

