### PR TITLE
Fix follow button initial visibility

### DIFF
--- a/src/components/profile/FollowButton.tsx
+++ b/src/components/profile/FollowButton.tsx
@@ -14,6 +14,7 @@ export function FollowButton({ userId, className }: FollowButtonProps) {
   const [isFollowing, setIsFollowing] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
   const [currentUserId, setCurrentUserId] = useState<string | null>(null)
+  const [isCheckingUser, setIsCheckingUser] = useState(true)
   const router = useRouter()
   const supabase = createClient()
 
@@ -24,6 +25,7 @@ export function FollowButton({ userId, className }: FollowButtonProps) {
       if (user) {
         setCurrentUserId(user.id)
       }
+      setIsCheckingUser(false)
     }
     getUser()
   }, [supabase])
@@ -83,8 +85,8 @@ export function FollowButton({ userId, className }: FollowButtonProps) {
     }
   }
 
-  // Don't show the button if the user is viewing their own profile
-  if (currentUserId === userId) {
+  // Don't show the button while checking the current user or if the user is viewing their own profile
+  if (isCheckingUser || currentUserId === userId) {
     return null
   }
 


### PR DESCRIPTION
Prevent the follow button from momentarily appearing on the user's own post detail screen.

The follow button would initially render before the current user's ID was known. If the fetched user ID matched the post's author ID, the button would then hide, causing a brief flicker. This change introduces a loading state to ensure the button is not rendered until the current user's ID has been determined.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce586a45-7a07-49a4-ab55-874c45a734c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ce586a45-7a07-49a4-ab55-874c45a734c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

