### PR TITLE
Fix page reloads due to auth state

### DIFF
--- a/src/components/posts/PostGrid.tsx
+++ b/src/components/posts/PostGrid.tsx
@@ -29,27 +29,16 @@ export function PostGrid({ initialPosts, loadMore, hasMore = false, enableLoadMo
     setPosts(initialPosts)
   }, [initialPosts])
   
-  // Refresh page when window regains focus to show new posts
+  // Update loadMore ref when it changes
   useEffect(() => {
-    const handleFocus = () => {
-      // Trigger a refresh to get latest posts
-      router.refresh()
-    }
+    if (!enableLoadMore || !loadMore) return
     
-    const handleVisibilityChange = () => {
-      if (!document.hidden) {
-        router.refresh()
-      }
-    }
-    
-    window.addEventListener('focus', handleFocus)
-    document.addEventListener('visibilitychange', handleVisibilityChange)
-    
-    return () => {
-      window.removeEventListener('focus', handleFocus)
-      document.removeEventListener('visibilitychange', handleVisibilityChange)
-    }
-  }, [])
+    loadMoreRef.current = loadMore || (async () => {
+      const response = await fetch(`/api/posts?offset=${posts.length}`)
+      if (!response.ok) throw new Error('Failed to load posts')
+      return response.json()
+    })
+  }, [enableLoadMore, loadMore, posts.length])
 
   const lastPostElementRef = useCallback(
     (node: HTMLDivElement) => {
@@ -64,16 +53,6 @@ export function PostGrid({ initialPosts, loadMore, hasMore = false, enableLoadMo
     },
     [loading, canLoadMore]
   )
-
-  useEffect(() => {
-    if (!enableLoadMore || !loadMore) return
-    
-    loadMoreRef.current = loadMore || (async () => {
-      const response = await fetch(`/api/posts?offset=${posts.length}`)
-      if (!response.ok) throw new Error('Failed to load posts')
-      return response.json()
-    })
-  }, [enableLoadMore, loadMore, posts.length])
 
   const handleLoadMore = async () => {
     if (!loadMoreRef.current || loading || !canLoadMore) return


### PR DESCRIPTION
Fix repeated page reloads by refining auth state handling in `AuthProvider` and removing unnecessary refreshes in `PostGrid`.

The previous implementation caused reload loops due to `AuthProvider` calling `router.refresh()` on various auth state changes and `PostGrid` refreshing on window focus. This PR prevents these excessive refreshes and ensures the application waits for the initial Supabase authentication state before rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-adf5f8ad-0e95-4165-8eeb-5e2b66783493">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-adf5f8ad-0e95-4165-8eeb-5e2b66783493">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

