### PR TITLE
Ensure FABs are circular with minimum tappable area

### DIFF
--- a/src/components/navigation/FABNavigation.tsx
+++ b/src/components/navigation/FABNavigation.tsx
@@ -60,7 +60,7 @@ export function FABNavigation({ items }: FABNavigationProps) {
                   color="primary"
                   variant="shadow"
                   size="lg"
-                  className="w-14 h-14"
+                  className="w-14 h-14 rounded-full"
                   onClick={() => handleItemClick(item)}
                   title={item.label}
                 >
@@ -79,7 +79,7 @@ export function FABNavigation({ items }: FABNavigationProps) {
         color="primary"
         variant="shadow"
         size="lg"
-        className="w-14 h-14"
+        className="w-14 h-14 rounded-full"
         onClick={() => setIsOpen(!isOpen)}
       >
         <motion.span


### PR DESCRIPTION
Ensure FABNavigation buttons are perfectly circular by adding the `rounded-full` class.

This change fulfills the requirement for all FABs to be regular circles. The minimum tapping area of 48px was already met by the existing 56px dimensions.

---
<a href="https://cursor.com/background-agent?bcId=bc-b5d3c8cf-54e7-4b92-91e9-522a22e7e3db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b5d3c8cf-54e7-4b92-91e9-522a22e7e3db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

