### PR TITLE
Adjust thumbnail layout for small screens

### DIFF
--- a/src/components/posts/MyPostsGrid.tsx
+++ b/src/components/posts/MyPostsGrid.tsx
@@ -119,7 +119,7 @@ export function MyPostsGrid({ userId, onEmptyState }: MyPostsGridProps) {
 
   return (
     <div className="w-full">
-      <div className="grid grid-cols-3 min-[640px]:grid-cols-4 gap-0">
+      <div className="grid grid-cols-3 min-[640px]:grid-cols-4 gap-0 max-[639px]:flex max-[639px]:flex-wrap max-[639px]:justify-center">
         {posts.map((post, index) => (
           <motion.div
             key={post.id}
@@ -127,7 +127,7 @@ export function MyPostsGrid({ userId, onEmptyState }: MyPostsGridProps) {
             initial={{ opacity: 0, scale: 0.9 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ delay: index * 0.02 }}
-            className="aspect-square-container cursor-pointer relative group"
+            className="aspect-square-container cursor-pointer relative group max-[639px]:flex-grow max-[639px]:flex-shrink-0 max-[639px]:basis-[33.333%] max-[639px]:max-w-[240px]"
             onClick={() => handlePostClick(post.id)}
           >
             <div className="aspect-square-content">

--- a/src/components/posts/PostGrid.tsx
+++ b/src/components/posts/PostGrid.tsx
@@ -76,7 +76,7 @@ export function PostGrid({ initialPosts, loadMore, hasMore = false, enableLoadMo
 
   return (
     <div className="w-full">
-      <div className="grid grid-cols-3 min-[640px]:grid-cols-4 gap-0">
+      <div className="grid grid-cols-3 min-[640px]:grid-cols-4 gap-0 max-[639px]:flex max-[639px]:flex-wrap max-[639px]:justify-center">
         {posts.map((post, index) => (
           <motion.div
             key={post.id}
@@ -84,7 +84,7 @@ export function PostGrid({ initialPosts, loadMore, hasMore = false, enableLoadMo
             initial={{ opacity: 0, scale: 0.9 }}
             animate={{ opacity: 1, scale: 1 }}
             transition={{ delay: index * 0.02 }}
-            className="aspect-square-container cursor-pointer relative group"
+            className="aspect-square-container cursor-pointer relative group max-[639px]:flex-grow max-[639px]:flex-shrink-0 max-[639px]:basis-[33.333%] max-[639px]:max-w-[240px]"
             onClick={() => handlePostClick(post.id)}
           >
             <div className="aspect-square-content">


### PR DESCRIPTION
Update post grid layouts for screens under 640px to maintain 3 columns with flexible, gap-free thumbnails up to 240px wide.

The previous `grid-cols-3` layout for screens under 640px did not allow for flexible thumbnail widths to fill available space or enforce a maximum width, leading to potential gaps or inconsistent sizing. This change uses flexbox to achieve the desired responsive behavior on the top page and My Page list.

---
<a href="https://cursor.com/background-agent?bcId=bc-70c7e8ec-663e-45ed-b052-95210b9efea4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-70c7e8ec-663e-45ed-b052-95210b9efea4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

