### PR TITLE
Make main pages scrollable

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -21,8 +21,8 @@ export default async function LocaleLayout({
 
   return (
     <NextIntlClientProvider messages={messages}>
-      <div className="min-h-screen flex flex-col">
-        <main className="flex-1 w-full">
+      <div className="min-h-screen flex flex-col h-screen overflow-hidden">
+        <main className="flex-1 w-full overflow-y-auto">
           {children}
         </main>
       </div>

--- a/src/app/[locale]/me/ProfileClient.tsx
+++ b/src/app/[locale]/me/ProfileClient.tsx
@@ -14,7 +14,7 @@ export function ProfileClient({ session }: ProfileClientProps) {
   const [hasNoPosts, setHasNoPosts] = useState(false)
 
   return (
-    <div className="min-h-screen">
+    <div className="h-full overflow-y-auto">
       {/* Posts Grid */}
       <MyPostsGrid 
         userId={session.user.id} 

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -57,12 +57,12 @@ export default async function HomePage() {
   ]
 
   return (
-    <>
+    <div className="h-full overflow-y-auto">
       <PostGridClient
         initialPosts={initialPosts}
         hasMore={initialPosts.length === POSTS_PER_PAGE}
       />
       <FABNavigation items={fabItems} />
-    </>
+    </div>
   )
 }

--- a/src/app/[locale]/settings/page.tsx
+++ b/src/app/[locale]/settings/page.tsx
@@ -192,9 +192,10 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="max-w-[480px] mx-auto space-y-6">
-      <div className="mb-6">
-      </div>
+    <div className="h-full overflow-y-auto pb-20">
+      <div className="max-w-[480px] mx-auto space-y-6 p-4">
+        <div className="mb-6">
+        </div>
       
       {user && (
         <Card>
@@ -407,9 +408,10 @@ export default function SettingsPage() {
         </CardBody>
       </Card>
       
-      {/* FAB Back Button */}
-      <div className="fixed bottom-6 left-6 z-50">
-        <BackButton variant="fab" />
+        {/* FAB Back Button */}
+        <div className="fixed bottom-6 left-6 z-50">
+          <BackButton variant="fab" />
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
Enable vertical scrolling for the Top, My, and Settings pages.

Previously, global CSS (`overflow: hidden` on html/body) and a lack of explicit scrollable containers prevented content from scrolling. This PR introduces `overflow-y-auto` on the main content areas and specific page wrappers to allow content to scroll within the app's fixed layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-7fcac4ad-5ff4-4ded-ab2d-e5372cae5462">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7fcac4ad-5ff4-4ded-ab2d-e5372cae5462">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

