### PR TITLE
Fix settings text color for dark mode

### DIFF
--- a/src/app/[locale]/settings/page.tsx
+++ b/src/app/[locale]/settings/page.tsx
@@ -222,6 +222,9 @@ export default function SettingsPage() {
                 isInvalid={!!usernameError}
                 errorMessage={usernameError}
                 isDisabled={isLoadingProfile || isSaving}
+                classNames={{
+                  input: "text-foreground"
+                }}
                 startContent={
                   <span className="material-symbols-rounded text-default-400">
                     person
@@ -314,6 +317,9 @@ export default function SettingsPage() {
             selectedKeys={[theme || 'system']}
             onSelectionChange={(keys) => setTheme(Array.from(keys)[0] as string)}
             className="max-w-full"
+            classNames={{
+              value: "text-foreground"
+            }}
           >
             <SelectItem key="system">
               {t('settings.themes.system')}
@@ -337,6 +343,9 @@ export default function SettingsPage() {
             selectedKeys={[currentLocale]}
             onSelectionChange={(keys) => handleLocaleChange(Array.from(keys)[0] as string)}
             className="max-w-full"
+            classNames={{
+              value: "text-foreground"
+            }}
           >
             {locales.map((locale) => (
               <SelectItem key={locale}>


### PR DESCRIPTION
Apply `text-foreground` class to settings fields (Username, Theme, Language) to resolve dark mode text visibility accessibility issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-c626d05f-c592-4a59-8a71-44892834bbfb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c626d05f-c592-4a59-8a71-44892834bbfb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

