### PR TITLE
Blur background on fab press

### DIFF
--- a/src/components/navigation/FABNavigation.tsx
+++ b/src/components/navigation/FABNavigation.tsx
@@ -38,58 +38,74 @@ export function FABNavigation({ items }: FABNavigationProps) {
   }
 
   return (
-    <div className="fixed bottom-6 right-6 z-50">
+    <>
+      {/* Blur Overlay */}
       <AnimatePresence>
         {isOpen && (
           <motion.div
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: 20 }}
-            className="absolute bottom-16 right-0 flex flex-col gap-3"
-          >
-            {items.map((item, index) => (
-              <motion.div
-                key={item.label}
-                initial={{ opacity: 0, x: 20 }}
-                animate={{ opacity: 1, x: 0 }}
-                exit={{ opacity: 0, x: 20 }}
-                transition={{ delay: index * 0.05 }}
-              >
-                <Button
-                  isIconOnly
-                  color="primary"
-                  variant="shadow"
-                  size="lg"
-                  className="w-14 h-14 rounded-full"
-                  onClick={() => handleItemClick(item)}
-                  title={item.label}
-                >
-                  <span className="material-symbols-rounded text-2xl">
-                    {item.icon}
-                  </span>
-                </Button>
-              </motion.div>
-            ))}
-          </motion.div>
+            className="fixed inset-0 backdrop-blur-md bg-black/30 z-40"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            onClick={() => setIsOpen(false)}
+          />
         )}
       </AnimatePresence>
 
-      <Button
-        isIconOnly
-        color="primary"
-        variant="shadow"
-        size="lg"
-        className="w-14 h-14 rounded-full"
-        onClick={() => setIsOpen(!isOpen)}
-      >
-        <motion.span
-          animate={{ rotate: isOpen ? 180 : 0 }}
-          transition={{ duration: 0.2 }}
-          className="material-symbols-rounded text-2xl"
+      <div className="fixed bottom-6 right-6 z-50">
+        <AnimatePresence>
+          {isOpen && (
+            <motion.div
+              initial={{ opacity: 0, y: 20 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: 20 }}
+              className="absolute bottom-16 right-0 flex flex-col gap-3"
+            >
+              {items.map((item, index) => (
+                <motion.div
+                  key={item.label}
+                  initial={{ opacity: 0, x: 20 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  exit={{ opacity: 0, x: 20 }}
+                  transition={{ delay: index * 0.05 }}
+                >
+                  <Button
+                    isIconOnly
+                    color="primary"
+                    variant="shadow"
+                    size="lg"
+                    className="w-14 h-14 rounded-full"
+                    onClick={() => handleItemClick(item)}
+                    title={item.label}
+                  >
+                    <span className="material-symbols-rounded text-2xl">
+                      {item.icon}
+                    </span>
+                  </Button>
+                </motion.div>
+              ))}
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        <Button
+          isIconOnly
+          color="primary"
+          variant="shadow"
+          size="lg"
+          className="w-14 h-14 rounded-full"
+          onClick={() => setIsOpen(!isOpen)}
         >
-          {isOpen ? 'close' : 'menu'}
-        </motion.span>
-      </Button>
-    </div>
+          <motion.span
+            animate={{ rotate: isOpen ? 180 : 0 }}
+            transition={{ duration: 0.2 }}
+            className="material-symbols-rounded text-2xl"
+          >
+            {isOpen ? 'close' : 'menu'}
+          </motion.span>
+        </Button>
+      </div>
+    </>
   )
 }

--- a/src/components/ui/FABMenu.tsx
+++ b/src/components/ui/FABMenu.tsx
@@ -45,6 +45,20 @@ export function FABMenu({ hasNoPosts = false }: FABMenuProps) {
 
   return (
     <>
+      {/* Blur Overlay */}
+      <AnimatePresence>
+        {isOpen && (
+          <motion.div
+            className="fixed inset-0 backdrop-blur-md bg-black/30 z-40"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2 }}
+            onClick={toggleMenu}
+          />
+        )}
+      </AnimatePresence>
+
       {/* Main FAB */}
       <motion.button
         className="fixed bottom-6 right-6 w-14 h-14 bg-primary text-white rounded-full shadow-lg flex items-center justify-center z-50"
@@ -64,7 +78,7 @@ export function FABMenu({ hasNoPosts = false }: FABMenuProps) {
           <>
             {/* Settings */}
             <motion.button
-              className="fixed bottom-6 right-6 w-14 h-14 bg-content2 text-foreground rounded-full shadow-lg flex items-center justify-center z-40"
+              className="fixed bottom-6 right-6 w-14 h-14 bg-content2 text-foreground rounded-full shadow-lg flex items-center justify-center z-50"
               initial={{ scale: 0, y: 0 }}
               animate={{ scale: 1, y: -200 }}
               exit={{ scale: 0, y: 0 }}
@@ -78,7 +92,7 @@ export function FABMenu({ hasNoPosts = false }: FABMenuProps) {
 
             {/* Home */}
             <motion.button
-              className="fixed bottom-6 right-6 w-14 h-14 bg-content2 text-foreground rounded-full shadow-lg flex items-center justify-center z-40"
+              className="fixed bottom-6 right-6 w-14 h-14 bg-content2 text-foreground rounded-full shadow-lg flex items-center justify-center z-50"
               initial={{ scale: 0, y: 0 }}
               animate={{ scale: 1, y: -140 }}
               exit={{ scale: 0, y: 0 }}
@@ -92,7 +106,7 @@ export function FABMenu({ hasNoPosts = false }: FABMenuProps) {
 
             {/* Post */}
             <motion.button
-              className="fixed bottom-6 right-6 w-14 h-14 bg-content2 text-foreground rounded-full shadow-lg flex items-center justify-center z-40"
+              className="fixed bottom-6 right-6 w-14 h-14 bg-content2 text-foreground rounded-full shadow-lg flex items-center justify-center z-50"
               initial={{ scale: 0, y: 0 }}
               animate={{ scale: 1, y: -80 }}
               exit={{ scale: 0, y: 0 }}


### PR DESCRIPTION
Add a blur overlay to the background when the FAB menu is open to improve focus and user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-77e6fa74-c6aa-4cbc-aadb-1b94971e4bc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-77e6fa74-c6aa-4cbc-aadb-1b94971e4bc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

