### PR TITLE
Set heroui primary foreground color

### DIFF
--- a/src/components/ui/FABMenu.tsx
+++ b/src/components/ui/FABMenu.tsx
@@ -27,7 +27,7 @@ export function FABMenu({ hasNoPosts = false }: FABMenuProps) {
   if (hasNoPosts) {
     return (
       <motion.button
-        className="fixed bottom-6 right-6 w-14 h-14 bg-primary text-white rounded-full flex items-center justify-center z-50"
+        className="fixed bottom-6 right-6 w-14 h-14 bg-primary text-primary-foreground rounded-full flex items-center justify-center z-50"
         whileHover={{ scale: 1.1 }}
         whileTap={{ scale: 0.9 }}
         onClick={() => handleNavigation('/create')}
@@ -61,7 +61,7 @@ export function FABMenu({ hasNoPosts = false }: FABMenuProps) {
 
       {/* Main FAB */}
       <motion.button
-        className="fixed bottom-6 right-6 w-14 h-14 bg-primary text-white rounded-full flex items-center justify-center z-50"
+        className="fixed bottom-6 right-6 w-14 h-14 bg-primary text-primary-foreground rounded-full flex items-center justify-center z-50"
         whileHover={{ scale: 1.1 }}
         whileTap={{ scale: 0.9 }}
         onClick={toggleMenu}


### PR DESCRIPTION
Update FABMenu to use `text-primary-foreground` for text on `bg-primary` elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc853c78-aa7a-4ccf-98b5-c3597b05f206">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc853c78-aa7a-4ccf-98b5-c3597b05f206">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

