### PR TITLE
Update settings colors to heroui-default-600

### DIFF
--- a/src/app/[locale]/settings/page.tsx
+++ b/src/app/[locale]/settings/page.tsx
@@ -223,7 +223,8 @@ export default function SettingsPage() {
                 errorMessage={usernameError}
                 isDisabled={isLoadingProfile || isSaving}
                 classNames={{
-                  input: "text-foreground"
+                  input: "text-foreground",
+                  label: "text-heroui-default-600"
                 }}
                 startContent={
                   <span className="material-symbols-rounded text-default-400">
@@ -318,7 +319,8 @@ export default function SettingsPage() {
             onSelectionChange={(keys) => setTheme(Array.from(keys)[0] as string)}
             className="max-w-full"
             classNames={{
-              value: "text-foreground"
+              value: "text-foreground",
+              label: "text-heroui-default-600"
             }}
           >
             <SelectItem key="system">
@@ -344,7 +346,8 @@ export default function SettingsPage() {
             onSelectionChange={(keys) => handleLocaleChange(Array.from(keys)[0] as string)}
             className="max-w-full"
             classNames={{
-              value: "text-foreground"
+              value: "text-foreground",
+              label: "text-heroui-default-600"
             }}
           >
             {locales.map((locale) => (


### PR DESCRIPTION
Change "Username", "Theme", and "Language" label colors to "heroui-default-600" in the settings screen.

---
<a href="https://cursor.com/background-agent?bcId=bc-424cfeb8-0985-466a-ba8d-f7f6d079368c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-424cfeb8-0985-466a-ba8d-f7f6d079368c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

